### PR TITLE
Add SecretsManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ No modules.
 | <a name="input_enable_lambda_endpoints"></a> [enable\_lambda\_endpoints](#input\_enable\_lambda\_endpoints) | Enable VPC endpoints for Lambda. | `bool` | `true` | no |
 | <a name="input_enable_s3_endpoints"></a> [enable\_s3\_endpoints](#input\_enable\_s3\_endpoints) | Enable VPC endpoints for S3. | `bool` | `true` | no |
 | <a name="input_enable_sagemaker_endpoints"></a> [enable\_sagemaker\_endpoints](#input\_enable\_sagemaker\_endpoints) | Enable VPC endpoints for SageMaker. | `bool` | `true` | no |
+| <a name="input_enable_secretsmanager_endpoints"></a> [enable\_secretsmanager\_endpoints](#input\_enable\_secretsmanager\_endpoints) | Enable VPC endpoints for SecretsManager. | `bool` | `true` | no |
 | <a name="input_enable_sns_endpoints"></a> [enable\_sns\_endpoints](#input\_enable\_sns\_endpoints) | Enable VPC endpoints for SNS. | `bool` | `true` | no |
 | <a name="input_enable_sqs_endpoints"></a> [enable\_sqs\_endpoints](#input\_enable\_sqs\_endpoints) | Enable VPC endpoints for SQS. | `bool` | `true` | no |
 | <a name="input_enable_ssm_endpoints"></a> [enable\_ssm\_endpoints](#input\_enable\_ssm\_endpoints) | Enable VPC endpoints for SSM. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,14 @@ locals {
       tags                = { Name = "sagemaker-runtime-vpc-endpoint" }
     },
 
+    # SecretsManager
+    ssm = {
+      enabled             = var.enable_secretsmanager_endpoints
+      service             = "secretsmanager"
+      private_dns_enabled = true
+      tags                = { Name = "secretsmanager-vpc-endpoint" }
+    },
+
     # SNS
 
     sns = {

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "enable_sagemaker_endpoints" {
   default     = true
 }
 
+variable "enable_secretsmanager_endpoints" {
+  type        = bool
+  description = "Enable VPC endpoints for SecretsManager."
+  default     = true
+}
+
 variable "enable_sns_endpoints" {
   type        = bool
   description = "Enable VPC endpoints for SNS."


### PR DESCRIPTION
if you want, @pjdufour-dds , i can add more services. i just need SecretsManager personally, right now.

here's a list i got from running `aws ec2 describe-vpc-endpoint-services` :
- access-analyzer
- acm-pca
- airflow.api
- airflow.env
- airflow.ops
- application-autoscaling
- appmesh
- appmesh-envoy-management
- apprunner
- apprunner.requests
- appstream.api
- appstream.streaming
- appsync-api
- aps
- aps-workspaces
- athena
- auditmanager
- autoscaling
- autoscaling-plans
- awsconnector
- backup
- backup-gateway
- batch
- bedrock
- bedrock-runtime
- cassandra
- cleanrooms
- cloudcontrolapi
- cloudcontrolapi-fips
- clouddirectory
- cloudformation
- cloudhsmv2
- cloudtrail
- codeartifact.api
- codeartifact.repositories
- codebuild
- codebuild-fips
- codecommit
- codecommit-fips
- codedeploy
- codedeploy-commands-secure
- codeguru-profiler
- codeguru-reviewer
- codepipeline
- codestar-connections.api
- com.amazonaws.s3-global.accesspoint
- comprehend
- comprehendmedical
- config
- console
- data-servicediscovery
- data-servicediscovery-fips
- databrew
- dataexchange
- datasync
- datazone
- devops-guru
- dms
- dms-fips
- drs
- dynamodb
- ebs
- ec2
- ec2messages
- ecr.api
- ecr.dkr
- ecs
- ecs-agent
- ecs-telemetry
- eks
- elastic-inference.runtime
- elasticache
- elasticache-fips
- elasticbeanstalk
- elasticbeanstalk-health
- elasticfilesystem
- elasticfilesystem-fips
- elasticloadbalancing
- elasticmapreduce
- email-smtp
- emr-containers
- emr-serverless
- events
- evidently
- evidently-dataplane
- execute-api
- finspace
- finspace-api
- fis
- forecast
- forecast-fips
- forecastquery
- forecastquery-fips
- frauddetector
- fsx
- fsx-fips
- git-codecommit
- git-codecommit-fips
- glue
- grafana
- grafana-workspace
- greengrass
- groundstation
- guardduty-data
- guardduty-data-fips
- healthlake
- identitystore
- imagebuilder
- inspector2
- iot.data
- iot.fleethub.api
- iotsitewise.api
- iotsitewise.data
- kendra
- kendra-ranking
- kinesis-firehose
- kinesis-streams
- kms
- kms-fips
- lakeformation
- lambda
- license-manager
- license-manager-fips
- license-manager-user-subscriptions
- logs
- lookoutmetrics
- lookoutvision
- m2
- macie2
- managedblockchain.bitcoin.mainnet
- managedblockchain.bitcoin.testnet
- mediaconnect
- memory-db
- memorydb-fips
- mgn
- monitoring
- notebook
- pca-connector-ad
- personalize
- personalize-events
- personalize-runtime
- pinpoint
- polly
- private-networks
- proton
- qldb.session
- rds
- rds-data
- redshift
- redshift-data
- redshift-fips
- refactor-spaces
- rekognition
- rekognition-fips
- robomaker
- rolesanywhere
- rum
- rum-dataplane
- s3
- s3-outposts
- sagemaker.api
- sagemaker.featurestore-runtime
- sagemaker.metrics
- sagemaker.runtime
- sagemaker.runtime-fips
- secretsmanager
- securityhub
- servicecatalog
- servicecatalog-appregistry
- servicediscovery
- servicediscovery-fips
- signin
- simspaceweaver
- sns
- sqs
- ssm
- ssm-contacts
- ssm-incidents
- ssmmessages
- states
- storagegateway
- sts
- studio
- swf
- swf-fips
- sync-states
- synthetics
- textract
- textract-fips
- transcribe
- transcribestreaming
- transfer
- transfer.server
- translate
- verifiedpermissions
- vpc-lattice
- xray